### PR TITLE
add flash lock guest commands

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,23 +17,6 @@
             },
             "args": [],
             "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug executable 'ignition'",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=ignition"
-                ],
-                "filter": {
-                    "name": "ignition",
-                    "kind": "bin"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
         }
     ]
 }

--- a/demos/postgres.yaml
+++ b/demos/postgres.yaml
@@ -4,15 +4,15 @@ volume:
   size: 50M
 ---
 machine:
-  image: postgres:17
+  image: ghcr.io/lttle-cloud/postgres:17-flash
   name: postgres-test
   resources:
     cpu: 1
     memory: 512
   mode:
     flash:
-      strategy:
-        listen-on-port: 5432
+      strategy: manual
+    # listen-on-port: 5432
   volumes:
     - name: postgres-data
       path: /var/lib/postgresql/data
@@ -27,6 +27,9 @@ service:
     name: postgres-test
     port: 5432
     protocol: tcp
+    connection-tracking:
+      traffic-aware:
+        inactivity-timeout: 5
   bind:
     external:
       host: pgtest.alpha1.ovh-rbx.lttle.host

--- a/demos/postgres/Dockerfile
+++ b/demos/postgres/Dockerfile
@@ -1,0 +1,17 @@
+FROM postgres:17 AS builder
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libpq-dev \
+    postgresql-server-dev-17
+
+WORKDIR /build
+
+COPY lttle_pg.c .
+COPY Makefile .
+RUN make clean
+RUN make
+
+FROM postgres:17
+COPY --from=builder /build/lttle_pg.so /etc/lttle/lttle_pg.so
+CMD ["postgres", "-c", "shared_preload_libraries=/etc/lttle/lttle_pg.so"]

--- a/demos/postgres/Makefile
+++ b/demos/postgres/Makefile
@@ -1,0 +1,6 @@
+MODULES = lttle_pg
+
+PGFILEDESC = "lttle_pg - lttle cloud flash mode support"
+
+PGXS := $(shell pg_config --pgxs)
+include $(PGXS)

--- a/demos/postgres/lttle_pg.c
+++ b/demos/postgres/lttle_pg.c
@@ -1,0 +1,136 @@
+#include "postgres.h"
+#include "fmgr.h"
+#include "executor/executor.h"
+#include "postmaster/bgworker.h"
+#include "storage/ipc.h"
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <signal.h>
+
+PG_MODULE_MAGIC;
+
+PGDLLEXPORT void flash_ready_worker(Datum arg);
+
+static ExecutorRun_hook_type onExecutorRunPrev;
+static void onExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count, bool execute_once);
+
+static int lttle_fd = -1;
+
+static int lttle_init(void);
+static int lttle_send_cmd(const char *cmd);
+static void flash_snapshot(void);
+static void flash_lock(void);
+static void flash_unlock(void);
+
+#define FLASH_LOCK_CMD     "flash_lock"
+#define FLASH_UNLOCK_CMD   "flash_unlock"
+#define FLASH_SNAPSHOT_CMD "manual_trigger"
+
+void _PG_init(void)
+{
+    BackgroundWorker worker;
+
+    elog(LOG, "lttle_pg: init");
+
+    if (lttle_init() < 0)
+    {
+        elog(LOG, "lttle_pg: failed to initialize lttle");
+        return;
+    }
+
+    onExecutorRunPrev = ExecutorRun_hook;
+	ExecutorRun_hook = onExecutorRun;
+
+    MemSet(&worker, 0, sizeof(worker));
+
+    worker.bgw_flags        = BGWORKER_SHMEM_ACCESS;
+    worker.bgw_start_time   = BgWorkerStart_RecoveryFinished;
+    worker.bgw_restart_time = BGW_NEVER_RESTART;
+
+    snprintf(worker.bgw_name,          BGW_MAXLEN,  "flash-ready");
+    snprintf(worker.bgw_library_name,  BGW_EXTRALEN, "/etc/lttle/lttle_pg.so");
+    snprintf(worker.bgw_function_name, BGW_EXTRALEN, "flash_ready_worker");
+
+    worker.bgw_main_arg = (Datum) 0;
+
+    RegisterBackgroundWorker(&worker);
+}
+
+void _PG_fini(void)
+{
+    elog(LOG, "lttle_pg: fini");
+}
+
+void flash_ready_worker(Datum arg)
+{    
+    elog(LOG, "lttle_pg: flash ready worker");
+
+    if (lttle_init() < 0)
+    {
+        elog(LOG, "lttle_pg: failed to initialize lttle");
+        return;
+    }
+
+    flash_snapshot();
+    proc_exit(0);
+}
+
+static void onExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count, bool execute_once)
+{
+    flash_lock();
+
+    PG_TRY();
+    {
+        if (onExecutorRunPrev)
+        {
+            (*onExecutorRunPrev)(queryDesc, direction, count, execute_once);
+        }
+        else
+        {
+            standard_ExecutorRun(queryDesc, direction, count, execute_once);
+        }
+    }
+    
+    PG_FINALLY();
+    {
+        flash_unlock();
+    }
+
+    PG_END_TRY();
+}
+
+static int lttle_init(void)
+{
+    lttle_fd = open("/proc/lttle", O_WRONLY);
+    if (lttle_fd < 0)
+        return -1;
+
+    return lttle_fd;
+}
+
+static int lttle_send_cmd(const char *cmd)
+{
+    if (lttle_fd < 0)
+        return -1;
+    
+    if (write(lttle_fd, cmd, strlen(cmd)) < 0)
+        return -1;
+
+    return 0;
+}
+
+static void flash_lock(void)
+{
+    lttle_send_cmd(FLASH_LOCK_CMD);
+}
+
+static void flash_unlock(void)
+{
+    lttle_send_cmd(FLASH_UNLOCK_CMD);
+}
+
+static void flash_snapshot(void)
+{
+    lttle_send_cmd(FLASH_SNAPSHOT_CMD);
+}

--- a/src/agent/machine/machine.rs
+++ b/src/agent/machine/machine.rs
@@ -543,6 +543,20 @@ impl Machine {
                             watcher_machine.stop().await.ok();
                         }
                     }
+                    DeviceEvent::FlashLock => {
+                        info!(
+                            "Flash lock requested for machine '{}'",
+                            watcher_machine.config.name
+                        );
+                        watcher_machine.increment_active_connection_count().await;
+                    }
+                    DeviceEvent::FlashUnlock => {
+                        info!(
+                            "Flash unlock requested for machine '{}'",
+                            watcher_machine.config.name
+                        );
+                        watcher_machine.decrement_active_connection_count().await;
+                    }
                 }
             }
         });

--- a/src/agent/machine/vm/devices/mod.rs
+++ b/src/agent/machine/vm/devices/mod.rs
@@ -47,6 +47,8 @@ pub struct VmDevices {
 pub enum DeviceEvent {
     UserSpaceReady,
     StopRequested,
+    FlashLock,
+    FlashUnlock,
 }
 
 pub async fn setup_devices(

--- a/src/agent/proxy/mod.rs
+++ b/src/agent/proxy/mod.rs
@@ -139,7 +139,8 @@ impl ProxyAgent {
         let mut tls_server_config =
             tls_server_config_builder.with_cert_resolver(tls_cert_resolver.clone());
 
-        tls_server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+        tls_server_config.alpn_protocols =
+            vec![b"postgresql".to_vec(), b"h2".to_vec(), b"http/1.1".to_vec()];
 
         let tls_acceptor = Arc::new(TlsAcceptor::from(Arc::new(tls_server_config)));
 


### PR DESCRIPTION
This features allows for running background jobs longer than the connection inactivity timeout for traffic-aware flash machines.